### PR TITLE
Added time indicator styling

### DIFF
--- a/blank-template/content.md
+++ b/blank-template/content.md
@@ -2,6 +2,8 @@
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam porttitor risus ut neque aliquet, ac lacinia est placerat. Phasellus eget nisi ligula. Nulla eleifend efficitur mattis. In hac habitasse platea dictumst. Etiam sit amet lacus metus. Praesent sit amet velit nisl. Quisque mattis, ex non consequat scelerisque, lacus mauris pharetra nunc, nec consequat magna felis eu elit. Integer a consequat leo. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
 
+<time>45-60 Minutes</time>
+
 * This is a bullet in an un-ordered list
 * This is a bullet in an un-ordered list
 * This is a bullet in an un-ordered list

--- a/blank-template/index.html
+++ b/blank-template/index.html
@@ -4,6 +4,7 @@
     <title></title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-XdYbMnZ/QjLh6iI4ogqCTaIjrFk87ip+ekIjefZch0Y+PvJ8CDYtEs1ipDmPorQ+" crossorigin="anonymous">
     <link href='https://fonts.googleapis.com/css?family=Fira+Sans:400,400italic,500,500italic,700' rel='stylesheet' type='text/css'>
     <link rel="icon" type="image/png" href="../template-assets/images/favicon.png">
     <link rel="stylesheet" href="../template-assets/css/style.css">

--- a/template-assets/css/style.css
+++ b/template-assets/css/style.css
@@ -262,3 +262,14 @@ nav a.selected:after {
     max-width: 100%;
   }
 }
+time {
+  background: #e5e6ea;
+  color: #3a3e4a;
+  padding: 6px 10px;
+  border-left: solid 2px #acb0bd;
+}
+time:before {
+  content: "\f017";
+  font-family: "FontAwesome";
+  margin-right: 6px;
+}


### PR DESCRIPTION
Also added Font Awesome to the blank-template to support it.

This is how it looks...
![image](https://cloud.githubusercontent.com/assets/25212/13541958/6528f47c-e214-11e5-96e3-c4f87dfa0875.png)

To add it in your content, use `<time>20-30 Minutes</time>` - it will display as a block level element on its own line.

If you want to use this markup and styling in existing guides, add the following code to the head of the index.html page (it's the Font Awesome stylesheet)...

```
<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-XdYbMnZ/QjLh6iI4ogqCTaIjrFk87ip+ekIjefZch0Y+PvJ8CDYtEs1ipDmPorQ+" crossorigin="anonymous">
```

Fixes #2 
